### PR TITLE
Increase memory on worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: production
+    shm_size: '512m'
     volumes:
       - ./files:/home/user/app/files
     depends_on:


### PR DESCRIPTION
This is a possible solution to #94.  Increasing memory so Puppeteer doesn't crash loading large pages.