### PR TITLE
limit videos downloaded to 1

### DIFF
--- a/specs/actions/PreserveEvidence.spec.ts
+++ b/specs/actions/PreserveEvidence.spec.ts
@@ -175,6 +175,7 @@ describe('PreserveEvidence', () => {
         format: 'best',
         output: `${config.data_path}/${evidence._id.toString()}/video.mp4`,
         addHeader: 'Cookie:a_name=a_value;another_name=another_value',
+        maxDownloads: 1,
       });
       videoDownloaderSpy.mockClear();
     }, 20000);

--- a/src/actions/PreserveEvidence.ts
+++ b/src/actions/PreserveEvidence.ts
@@ -90,15 +90,20 @@ export class PreserveEvidence {
         const text = await page.evaluate(() => document.body.innerText);
         const content_path = path.join(evidence._id.toString(), 'content.txt');
         await appendFile(path.join(evidence_dir, 'content.txt'), text);
+        const title = (await page.title()) || evidence.attributes.url;
+
+        await browserless.destroyContext();
+        await browserlessFactory.close();
 
         const video_path = await this.videoDownloader.download(evidence, {
           output: path.join(evidence_dir, 'video.mp4'),
           format: 'best',
           addHeader: `Cookie:${cookie}`,
+          maxDownloads: 1,
         });
 
         const result: PreservationResults = {
-          title: (await page.title()) || evidence.attributes.url,
+          title,
           downloads: [
             { path: html_content_path, type: 'content' },
             { path: content_path, type: 'content' },
@@ -108,8 +113,6 @@ export class PreserveEvidence {
           ],
         };
 
-        await browserless.destroyContext();
-        await browserlessFactory.close();
         resolve(result);
       } catch (e) {
         reject(e);


### PR DESCRIPTION
this solves an issue where the worker downloads full playlists and can be doing that for hours, out implementation only assumes one video in the downloads for now, lets see if we want more in the future.